### PR TITLE
Ammend navigation items for core docs

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1017,20 +1017,6 @@ core:
     - title: Docs
       path: /core/docs
       persist: True
-      hidden: True
-
-      children:
-        - title: Bluetooth management
-          path: /core/docs/bluetooth-management
-          persist: True
-        - title: Network management
-          path: /core/docs/network-management-services
-          persist: True
-        - title: Audio management
-          path: /core/docs/audio-management
-          persist: True
-
-
 
     - title: Contact us
       path: /core/contact-us
@@ -1040,7 +1026,6 @@ core:
         - title: Thank you
           path: /core/thank-you
           hidden: True
-
 
 
 iot:

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -81,7 +81,7 @@
     <div class="col-6">
       <h3 class="p-card__title">FIPS certification and CIS compliance with Ubuntu</h3>
       <p class="p-card__content u-sv3">Learn about Ubuntu CIS and FIPS certified components to enable operating under compliance regimes like FedRAMP, HIPAA, PCI and ISO. Get all of your compliance questions answered in our upcoming webinar to ensure you and your team are, and remain, compliant.</p>
-      <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/432536">Register for the webinar</a></p>
+      <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/432536">Watch the webinar</a></p>
     </div>
   </div>
 </section>
@@ -166,8 +166,8 @@
         DISA has, in conjunction with Canonical, developed STIGs for Ubuntu 16.04 LTS and Ubuntu 18.04 LTS.
       </p>
       <ul class="p-list">
-        <li class="p-list__item"><a class="p-link--external" href="https://nvd.nist.gov/ncp/checklist/859">STIG checklist for Ubuntu 16.04 LTS</a></li>
-        <li class="p-list__item"><a class="p-link--external" href="https://nvd.nist.gov/ncp/checklist/950">STIG checklist for Ubuntu 18.04 LTS</a></li>
+        <li class="p-list__item"><a class="p-link--external" href="https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux">STIG checklist for Ubuntu 16.04 LTS and 18.04 LTS</a></li>
+        <li class="p-list__item"><a class="p-link--external" href="https://public.cyber.mil/stigs/scap/">STIG content for Ubuntu 16.04 LTS and 18.04 LTS</a></li>
       </ul>
     </div>
     <div class="col-4 u-align--center u-hide--small">

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -209,7 +209,12 @@
                           Fixed by
                           <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}" target="_blank">{{ patch.content.fixed }}</a>
                         {% elif patch.type == "link" %}
-                          {{ patch.content.prefix }}: <a href="{{ patch.content.suffix }}" target="_blank">{{ patch.content.suffix }}</a>
+                          {{ patch.content.prefix }}:
+                          {% if cve._clean_url(patch.content.suffix) %}
+                            <a href="{{ cve._clean_url(patch.content.suffix) }}" target="_blank">{{ patch.content.suffix }}</a>
+                          {% else %}
+                            {{ patch.content.suffix }}
+                          {% endif %}
                         {% endif %}
                         <br>
                       {% endfor %}
@@ -275,7 +280,9 @@
         <ul>
           {% if cve.references %}
             {% for reference in cve.references %}
-            <li><a href="{{ reference }}">{{ reference }}</a></li>
+              {% if cve._clean_url(reference) %}
+                <li><a href="{{ cve._clean_url(reference) }}">{{ reference }}</a></li>
+              {% endif %}
             {% endfor %}
           {% else %}
             <li>
@@ -300,12 +307,14 @@
         </ul>
 
         {% if cve.bugs %}
-        <h2>Bugs</h2>
-        <ul>
-          {% for bug in cve.bugs %}
-          <li><a href="{{ bug }}">{{ bug }}</a></li>
-          {% endfor %}
-        </ul>
+          <h2>Bugs</h2>
+          <ul>
+            {% for bug in cve.bugs %}
+              {% if cve._clean_url(bug) %}
+                <li><a href="{{ cve._clean_url(bug) }}">{{ bug }}</a></li>
+              {% endif %}
+            {% endfor %}
+          </ul>
         {% endif %}
       </div>
     </div>

--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -14,7 +14,7 @@
         Ubuntu OVAL data
       </h1>
       <p>
-        Canonical's Security Team produces Ubuntu OVAL, a structured, machine-readable dataset for all <a href="https://ubuntu.com/about/release-cycle">supported Ubuntu releases</a>.  It can be used to evaluate and manage security risk related to any existing Ubuntu components. It is based on the Open Vulnerability and Assessment Language (OVAL).
+        Canonical's Security Team produces Ubuntu OVAL, a structured, machine-readable dataset for all <a href="/about/release-cycle">supported Ubuntu releases</a>.  It can be used to evaluate and manage security risks related to any existing Ubuntu components. It is based on the Open Vulnerability and Assessment Language (OVAL).
       </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
@@ -44,6 +44,7 @@
       <p>
         Ubuntu OVAL also allows for any third-party Security Content Automation Protocol (SCAP) compliant tools to accurately scan an Ubuntu system or an official Ubuntu OCI image for vulnerabilities.
       </p>
+      <a class="p-button--neutral" href="/security/notices">See the Ubuntu Security Notices</a>
     </div>
     <div class="col-5 u-hide--small u-align--center">
       {{
@@ -77,15 +78,15 @@
             <p>
               Download the compressed XML:
             </p>
-            <pre><code>wget https://security-metadata.canonical.com/oval/com.ubuntu.$(lsb_release -cs).cve.oval.xml.bz2</code></pre>
+            <pre><code>wget https://security-metadata.canonical.com/oval/com.ubuntu.$(lsb_release -cs).usn.oval.xml.bz2</code></pre>
             <p>
               Uncompress the data:
             </p>
-            <pre><code>bunzip2 com.ubuntu.$(lsb_release -cs).cve.oval.xml.bz2</code></pre>
+            <pre><code>bunzip2 com.ubuntu.$(lsb_release -cs).usn.oval.xml.bz2</code></pre>
             <p>
               Use OpenSCAP to evaluate the OVAL and generate an html report:
             </p>
-            <pre><code>oscap oval eval --report report.html com.ubuntu.$(lsb_release -cs).cve.oval.xml</code></pre>
+            <pre><code>oscap oval eval --report report.html com.ubuntu.$(lsb_release -cs).usn.oval.xml</code></pre>
             <p>
               The output is generated in the file report.html, open it using your browser:
             </p>
@@ -93,8 +94,7 @@
             <p>
               File naming convention:
             </p>
-            <pre><code>com.ubuntu.&lt;example release name&gt;.cve.oval.xml.bz2
-com.ubuntu.&lt;example release name&gt;.usn.oval.xml.bz2</code></pre>
+            <pre><code>com.ubuntu.&lt;example release name&gt;.usn.oval.xml.bz2</code></pre>
             </div>
           </li>
           <li class="p-stepped-list__item">
@@ -108,8 +108,8 @@ com.ubuntu.&lt;example release name&gt;.usn.oval.xml.bz2</code></pre>
               <p>
                 <i class="p-icon--information">Note:</i> In the example below we are using focal/20.04, you would replace 'focal' with the version you are inspecting.
               </p>
-              <pre><code>wget https://security-metadata.canonical.com/oval/oci.com.ubuntu.focal.cve.oval.xml.bz2
-bunzip2 oci.com.ubuntu.focal.cve.oval.xml.bz2</code></pre>
+              <pre><code>wget https://security-metadata.canonical.com/oval/oci.com.ubuntu.focal.usn.oval.xml.bz2
+bunzip2 oci.com.ubuntu.focal.usn.oval.xml.bz2</code></pre>
                 <p>
                   Download the manifest file for the image
                 </p>
@@ -117,7 +117,7 @@ bunzip2 oci.com.ubuntu.focal.cve.oval.xml.bz2</code></pre>
                 <p>
                   Use OpenSCAP to evaluate the OVAL and generate an html report
                 </p>
-                <pre><code>oscap oval eval --report report.html oci.com.ubuntu.focal.cve.oval.xml</code></pre>
+                <pre><code>oscap oval eval --report report.html oci.com.ubuntu.focal.usn.oval.xml</code></pre>
                 <p>
                   The output is generated in the file <code>report.html</code>, open it using your browser
                 </p>
@@ -125,7 +125,7 @@ bunzip2 oci.com.ubuntu.focal.cve.oval.xml.bz2</code></pre>
                 <p>
                   File naming convention:
                 </p>
-                <pre><code>oci.com.ubuntu.&lt;example release name&gt;.cve.oval.xml.bz2</code></pre>
+                <pre><code>oci.com.ubuntu.&lt;example release name&gt;.usn.oval.xml.bz2</code></pre>
               </div>
             </li>
           </ol>

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -121,6 +121,18 @@ class CVE(Base):
 
         return {"type": "text", "content": patch}
 
+    def _clean_url(self, dirty_url):
+        new_url = re.sub(r"\(.*?\)", "", dirty_url)
+        url_check_regex = re.compile(
+            r"^(?:http|ftp)s?:\/\/[-a-zA-Z0-9@:%._\+~#=]{1,256}\."
+            r"[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&\/\/=]*)",
+            re.IGNORECASE,
+        )
+
+        is_url = re.match(url_check_regex, new_url) is not None
+
+        return new_url if is_url else ""
+
 
 class Notice(Base):
     __tablename__ = "notice"


### PR DESCRIPTION
## Done

Core docs release navigation items.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/core/docs
- Check navigation items corresponds with issue request.

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
